### PR TITLE
feat(auth): add user permission persistence and seeding

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "postinstall": "prisma generate"
+    "postinstall": "prisma generate",
+    "seed": "node prisma/seed.js"
+  },
+  "prisma": {
+    "seed": "node prisma/seed.js"
   },
   "dependencies": {
     "@prisma/client": "^6.13.0",

--- a/prisma/migrations/20251219114454_add_user_permissions/migration.sql
+++ b/prisma/migrations/20251219114454_add_user_permissions/migration.sql
@@ -1,0 +1,32 @@
+-- CreateTable
+CREATE TABLE "public"."Permission" (
+    "id" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Permission_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."UserPermission" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "permissionId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UserPermission_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Permission_key_key" ON "public"."Permission"("key");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserPermission_userId_permissionId_key" ON "public"."UserPermission"("userId", "permissionId");
+
+-- AddForeignKey
+ALTER TABLE "public"."UserPermission" ADD CONSTRAINT "UserPermission_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."UserPermission" ADD CONSTRAINT "UserPermission_permissionId_fkey" FOREIGN KEY ("permissionId") REFERENCES "public"."Permission"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,13 +17,14 @@ enum Role {
 }
 
 model User {
-  id        String   @id @default(uuid())
-  email     String   @unique
-  password  String
-  role      Role     @default(USER)
-  profile   Profile?
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt @default(now())
+  id          String           @id @default(uuid())
+  email       String           @unique
+  password    String
+  role        Role             @default(USER)
+  profile     Profile?
+  permissions UserPermission[]
+  createdAt   DateTime         @default(now())
+  updatedAt   DateTime         @default(now()) @updatedAt
 }
 
 model Profile {
@@ -34,7 +35,27 @@ model Profile {
   userId    String   @unique
   user      User     @relation(fields: [userId], references: [id])
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+}
+
+model Permission {
+  id        String           @id @default(uuid())
+  key       String           @unique
+  users     UserPermission[]
+  createdAt DateTime         @default(now())
+  updatedAt DateTime         @updatedAt
+}
+
+model UserPermission {
+  id           String     @id @default(uuid())
+  user         User       @relation(fields: [userId], references: [id])
+  userId       String
+  permission   Permission @relation(fields: [permissionId], references: [id])
+  permissionId String
+  createdAt    DateTime   @default(now())
+  updatedAt    DateTime   @updatedAt
+
+  @@unique([userId, permissionId])
 }
 
 model Product {

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -1,0 +1,20 @@
+import { PrismaClient } from '../src/generated/prisma/index.js'
+import { PERMISSIONS } from '../src/auth/permissions/permission-keys.js'
+
+const prisma = new PrismaClient()
+
+async function main() {
+    for (const key of Object.values(PERMISSIONS)) {
+        await prisma.permission.upsert({
+            where: { key },
+            update: {},
+            create: { key },
+        })
+    }
+
+    console.log('Permissions seeded successfully')
+}
+
+main()
+    .catch(console.error)
+    .finally(() => prisma.$disconnect())

--- a/src/auth/permissions/user-permissions.js
+++ b/src/auth/permissions/user-permissions.js
@@ -1,0 +1,17 @@
+// import { PrismaClient } from '@prisma/client'
+import { PrismaClient } from '../src/generated/prisma/index.js'
+
+const prisma = new PrismaClient()
+
+export async function getUserExtraPermissions(userId) {
+    const records = await prisma.userPermission.findMany({
+        where: { userId },
+        select: {
+            permission: {
+                select: { key: true },
+            },
+        },
+    })
+
+    return records.map(r => r.permission.key)
+}


### PR DESCRIPTION
- Added Permission and UserPermission models
- Linked users to assignable permissions
- Seeded permission keys from code
- Updated Prisma client imports to use custom generated output