### PR TITLE
feat(profile): implement multi-step profile completion form

### DIFF
--- a/src/app/(dashboard)/dashboard/profile-completion/page.jsx
+++ b/src/app/(dashboard)/dashboard/profile-completion/page.jsx
@@ -1,0 +1,22 @@
+import ProfileCompletionForm from '@/components/profiles/ProfileCompletionForm';
+import { requireRole } from '@/libs/authGuard';
+import { prisma } from '@/libs/prisma';
+
+export default async function ProfileCompletionPage() {
+    // Ensure user is logged in and allowed
+    const session = await requireRole(['USER', 'FARMER', 'INVESTOR']);
+
+    // Fetch full user data including profile
+    const user = await prisma.user.findUnique({
+        where: { id: session.user.id },
+        include: {
+            profile: true,
+        },
+    });
+
+    if (!user) {
+        throw new Error('User not found');
+    }
+
+    return <ProfileCompletionForm user={user} />;
+}

--- a/src/app/(dashboard)/dashboard/profile/page.jsx
+++ b/src/app/(dashboard)/dashboard/profile/page.jsx
@@ -1,0 +1,214 @@
+'use client';
+
+import React, { useState } from 'react';
+import '../../dashboard.css';
+import { ProgressBar } from 'react-bootstrap';
+import 'bootstrap-icons/font/bootstrap-icons.css';
+import Image from 'next/image';
+
+export default function FarmerProfilePage() {
+  // Farmer info
+  const [farmer, setFarmer] = useState({
+    name: 'John Doe',
+    location: 'Corn & Wheat Farmer | Central Valley, California',
+    email: 'john.doe@example.com',
+    phone: '+1 234 567 890',
+    badgeLevel: 'Pro Level',
+    badgeTitle: 'Outstanding Agricultural Innovator',
+    badgeDescription: 'Keep innovating and inspiring others!',
+    profileCompleteness: 85,
+    communityEngagement: 72,
+  });
+
+  // Edit form state
+  const [isEditing, setIsEditing] = useState(false);
+
+  // Badge verification status
+  const [verificationStatus, setVerificationStatus] = useState('success');
+  // options: 'success', 'warning', 'danger'
+
+  // Handle form update
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFarmer((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    setIsEditing(false);
+    alert('Profile updated successfully!');
+  };
+
+  // Badge Display Switch
+  const getBadge = (status) => {
+    switch (status) {
+      case 'success':
+        return (
+          <div className="verified-badge bg-success text-white">
+            <i className="bi bi-check-lg"></i>
+          </div>
+        );
+      case 'warning':
+        return (
+          <div className="verified-badge bg-warning text-dark">
+            <i className="bi bi-hourglass-split"></i>
+          </div>
+        );
+      case 'danger':
+        return (
+          <div className="verified-badge bg-danger text-white">
+            <i className="bi bi-x-lg"></i>
+          </div>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="dashboard-container py-4">
+      {/* Header */}
+      <div className="profile-header card p-4 mb-4 shadow-sm rounded-4 text-center bg-light-green">
+        <div className="d-flex flex-column align-items-center">
+          <div className="profile-img-wrapper mb-2">
+            <Image
+              src="https://media.istockphoto.com/id/2208264034/photo/portrait-of-confident-farmer-in-agriculture-field.webp?a=1&b=1&s=612x612&w=0&k=20&c=SXe0T5TlAhr-B7-Oh-VVslVNr2KMiAAiY53RzrhofcE="
+              alt="Farmer"
+              className="rounded-circle border border-3 border-success"
+              style={{ width: '90px', height: '90px', objectFit: 'cover' }}
+            />
+          </div>
+          <h4 className="fw-bold text-success mb-0">{farmer.name}</h4>
+          <p className="text-muted small">{farmer.location}</p>
+        </div>
+      </div>
+
+      {/* Farmer Badge */}
+      <div className="card p-4 mb-4 shadow-sm rounded-4">
+        <div className="d-flex justify-content-between align-items-center mb-3">
+          <h6 className="fw-bold mb-0 text-success">Farmer Badge</h6>
+          <span className="badge bg-warning text-white px-3 py-2 rounded-pill">
+            {farmer.badgeLevel}
+          </span>
+        </div>
+
+        <div className="text-center">
+          {getBadge(verificationStatus)}
+          <h6 className="fw-bold text-success mt-3">{farmer.badgeTitle}</h6>
+          <p className="text-muted small">{farmer.badgeDescription}</p>
+        </div>
+      </div>
+
+      {/* Progress Tracker */}
+      <div className="card p-4 mb-4 shadow-sm rounded-4">
+        <h6 className="fw-bold text-success mb-3">Progress Tracker</h6>
+
+        <div className="mb-3">
+          <div className="d-flex justify-content-between small mb-1">
+            <span>Profile Completeness</span>
+            <span>{farmer.profileCompleteness}%</span>
+          </div>
+          <ProgressBar
+            now={farmer.profileCompleteness}
+            variant="success"
+            style={{ height: '7px', borderRadius: '10px' }}
+          />
+        </div>
+
+        <div className="mb-3">
+          <div className="d-flex justify-content-between small mb-1">
+            <span>Community Engagement</span>
+            <span>{farmer.communityEngagement}%</span>
+          </div>
+          <ProgressBar
+            now={farmer.communityEngagement}
+            variant="warning"
+            style={{ height: '7px', borderRadius: '10px' }}
+          />
+        </div>
+
+        <p className="text-muted small mb-0">Keep engaging and growing!</p>
+      </div>
+
+      {/* Edit Profile Form */}
+      <div className="card p-4 shadow-sm rounded-4">
+        <div className="d-flex justify-content-between align-items-center mb-3">
+          <h6 className="fw-bold text-success mb-0">Edit Profile</h6>
+          <button
+            className="btn btn-outline-success btn-sm"
+            onClick={() => setIsEditing(!isEditing)}
+          >
+            {isEditing ? 'Cancel' : 'Edit'}
+          </button>
+        </div>
+
+        {isEditing ? (
+          <form onSubmit={handleSubmit}>
+            <div className="mb-3">
+              <label className="form-label small fw-bold">Full Name</label>
+              <input
+                type="text"
+                name="name"
+                value={farmer.name}
+                onChange={handleChange}
+                className="form-control"
+              />
+            </div>
+
+            <div className="mb-3">
+              <label className="form-label small fw-bold">Location</label>
+              <input
+                type="text"
+                name="location"
+                value={farmer.location}
+                onChange={handleChange}
+                className="form-control"
+              />
+            </div>
+
+            <div className="mb-3">
+              <label className="form-label small fw-bold">Email</label>
+              <input
+                type="email"
+                name="email"
+                value={farmer.email}
+                onChange={handleChange}
+                className="form-control"
+              />
+            </div>
+
+            <div className="mb-3">
+              <label className="form-label small fw-bold">Phone</label>
+              <input
+                type="text"
+                name="phone"
+                value={farmer.phone}
+                onChange={handleChange}
+                className="form-control"
+              />
+            </div>
+
+            <button type="submit" className="btn btn-success w-100 fw-bold">
+              Save Changes
+            </button>
+          </form>
+        ) : (
+          <div>
+            <p className="mb-1">
+              <strong>Name:</strong> {farmer.name}
+            </p>
+            <p className="mb-1">
+              <strong>Email:</strong> {farmer.email}
+            </p>
+            <p className="mb-1">
+              <strong>Phone:</strong> {farmer.phone}
+            </p>
+            <p className="mb-0">
+              <strong>Location:</strong> {farmer.location}
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/user/profile/route.js
+++ b/src/app/api/user/profile/route.js
@@ -1,45 +1,93 @@
 import { prisma } from '@/libs/prisma';
-import { getSession } from "next-auth/react";
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/libs/auth';
+import { NextResponse } from 'next/server';
 
-// GET: fetch current user profile
-export async function GET(req) {
-    const session = await getSession(req);
-    if (!session) return new Response("Unauthorized", { status: 401 });
+/**
+ * GET – Fetch current user with profile
+ */
+export async function GET() {
+    const session = await getServerSession(authOptions);
+    if (!session) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
 
     const user = await prisma.user.findUnique({
         where: { id: session.user.id },
         include: { profile: true },
     });
 
-    if (!user) return new Response("User not found", { status: 404 });
+    if (!user) {
+        return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
 
-    return new Response(JSON.stringify(user), { status: 200 });
+    return NextResponse.json(user);
 }
 
-// PUT: update profile and/or role-specific info
-export async function PUT(req) {
-    const session = await getSession(req);
-    if (!session) return new Response("Unauthorized", { status: 401 });
+/**
+ * PATCH – Update profile progressively (multi-step)
+ */
+export async function PATCH(req) {
+    const session = await getServerSession(authOptions);
+    if (!session) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
 
-    const data = await req.json();
-    const { firstName, lastName, phone, roleSpecific, documents } = data;
+    const {
+        firstName,
+        lastName,
+        phone,
+        roleSpecific,
+        documents,
+        profileStage,
+    } = await req.json();
 
-    const updatedProfile = await prisma.profile.upsert({
+    // Upsert profile
+    await prisma.profile.upsert({
         where: { userId: session.user.id },
-        update: { firstName, lastName, phone, roleSpecific, documents, updatedAt: new Date() },
-        create: { userId: session.user.id, firstName, lastName, phone, roleSpecific, documents },
+        update: {
+            ...(firstName !== undefined && { firstName }),
+            ...(lastName !== undefined && { lastName }),
+            ...(phone !== undefined && { phone }),
+            ...(roleSpecific !== undefined && { roleSpecific }),
+            ...(documents !== undefined && { documents }),
+        },
+        create: {
+            userId: session.user.id,
+            firstName,
+            lastName,
+            phone,
+            roleSpecific,
+            documents,
+        },
     });
 
-    // Optional: Update profile completion percentage
+    // --- Calculate completion percentage safely ---
     let completionPct = 0;
-    if (firstName && lastName && phone) completionPct += 40;
-    if (roleSpecific) completionPct += 40;
-    if (documents) completionPct += 20;
 
+    if (firstName && lastName) completionPct += 30;
+    if (phone) completionPct += 10;
+
+    if (roleSpecific && Object.keys(roleSpecific).length > 0) {
+        completionPct += 40;
+    }
+
+    if (documents && Array.isArray(documents) && documents.length > 0) {
+        completionPct += 20;
+    }
+
+    // Update user onboarding progress
     await prisma.user.update({
         where: { id: session.user.id },
-        data: { profileStage: 4, profileCompletionPct: completionPct, updatedAt: new Date() },
+        data: {
+            ...(profileStage !== undefined && { profileStage }),
+            profileCompletionPct: completionPct,
+        },
     });
 
-    return new Response(JSON.stringify(updatedProfile), { status: 200 });
+    return NextResponse.json({
+        success: true,
+        profileStage,
+        profileCompletionPct: completionPct,
+    });
 }

--- a/src/components/dashboard/states/ProfileInProgress.jsx
+++ b/src/components/dashboard/states/ProfileInProgress.jsx
@@ -13,7 +13,7 @@ export default function ProfileInProgress({ user }) {
                 />
             </div>
 
-            <Link href="/dashboard/profile" className="btn btn-warning">
+            <Link href="/dashboard/profile-completion" className="btn btn-warning">
                 Continue Profile
             </Link>
         </div>

--- a/src/components/dashboard/states/StartProfile.jsx
+++ b/src/components/dashboard/states/StartProfile.jsx
@@ -5,7 +5,7 @@ export default function StartProfile() {
         <div className="card p-4">
             <h4>Welcome 👋</h4>
             <p>To continue, please complete your profile.</p>
-            <Link href="/dashboard/profile" className="btn btn-primary">
+            <Link href="/dashboard/profile-completion" className="btn btn-primary">
                 Start Profile
             </Link>
         </div>

--- a/src/components/profiles/ProfileCompletionForm.jsx
+++ b/src/components/profiles/ProfileCompletionForm.jsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+import StepPersonalInfo from './steps/StepPersonalInfo';
+import StepRoleSpecific from './steps/StepRoleSpecific';
+import StepDocumentsUpload from './steps/StepDocumentsUpload';
+import StepReviewSubmit from './steps/StepReviewSubmit';
+import ProgressTracker from './steps/ProgressTracker';
+
+const TOTAL_STEPS = 4; // 0 - 3
+
+export default function ProfileCompletionForm({ user }) {
+    const router = useRouter();
+
+    /**
+     * 🔒 Clamp backend profileStage to UI-safe range
+     * Prevents invisible step bug forever
+     */
+    const initialStep = Math.min(
+        user.profileStage ?? 0,
+        TOTAL_STEPS - 1
+    );
+
+    const [currentStep, setCurrentStep] = useState(initialStep);
+
+    /**
+     * Editable until APPROVED
+     */
+    const isLocked = user.verificationStatus === 'APPROVED';
+
+    const [formData, setFormData] = useState({
+        firstName: user.profile?.firstName || '',
+        lastName: user.profile?.lastName || '',
+        phone: user.profile?.phone || '',
+        roleSpecific: user.profile?.roleSpecific || {},
+        documents: user.profile?.documents || [],
+    });
+
+    /**
+     * Progress derived from backend truth
+     * NOT navigation state
+     */
+    const progressPct = Math.min(
+        user.profileCompletionPct || 0,
+        100
+    );
+
+    const nextStep = () =>
+        setCurrentStep((prev) => Math.min(prev + 1, TOTAL_STEPS - 1));
+
+    const prevStep = () =>
+        setCurrentStep((prev) => Math.max(prev - 1, 0));
+
+    const updateFormData = (field, value) => {
+        setFormData((prev) => ({ ...prev, [field]: value }));
+    };
+
+    /**
+     * 🚫 Client no longer sends profileStage
+     * Backend owns completion logic
+     */
+    const handleSubmit = async () => {
+        try {
+            const res = await fetch('/api/user/profile', {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(formData),
+            });
+
+            const data = await res.json();
+            if (!res.ok) throw new Error(data.error || 'Submission failed');
+
+            router.refresh(); // reload with updated server state
+        } catch (err) {
+            console.error(err);
+            alert(err.message);
+        }
+    };
+
+    if (isLocked) {
+        return (
+            <div className="alert alert-info">
+                Your profile is under review. Editing is disabled.
+            </div>
+        );
+    }
+
+    return (
+        <div className="profile-completion-form container py-4">
+            <ProgressTracker progress={progressPct} />
+
+            <div className="form-steps mt-4">
+                {currentStep === 0 && (
+                    <StepPersonalInfo
+                        data={formData}
+                        updateData={updateFormData}
+                        nextStep={nextStep}
+                    />
+                )}
+
+                {currentStep === 1 && (
+                    <StepRoleSpecific
+                        role={user.requestedRole}
+                        data={formData.roleSpecific}
+                        updateData={(val) => updateFormData('roleSpecific', val)}
+                        nextStep={nextStep}
+                        prevStep={prevStep}
+                    />
+                )}
+
+                {currentStep === 2 && (
+                    <StepDocumentsUpload
+                        documents={formData.documents}
+                        updateData={(docs) => updateFormData('documents', docs)}
+                        nextStep={nextStep}
+                        prevStep={prevStep}
+                    />
+                )}
+
+                {currentStep === 3 && (
+                    <StepReviewSubmit
+                        data={formData}
+                        prevStep={prevStep}
+                        handleSubmit={handleSubmit}
+                    />
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/components/profiles/steps/ProgressTracker.jsx
+++ b/src/components/profiles/steps/ProgressTracker.jsx
@@ -1,0 +1,14 @@
+export default function ProgressTracker({ progress }) {
+    return (
+        <div className="progress mb-4" style={{ height: '8px' }}>
+            <div
+                className="progress-bar bg-success"
+                role="progressbar"
+                style={{ width: `${progress}%` }}
+                aria-valuenow={progress}
+                aria-valuemin="0"
+                aria-valuemax="100"
+            ></div>
+        </div>
+    );
+}

--- a/src/components/profiles/steps/StepDocumentsUpload.jsx
+++ b/src/components/profiles/steps/StepDocumentsUpload.jsx
@@ -1,0 +1,32 @@
+export default function StepDocumentsUpload({ documents, updateData, nextStep, prevStep }) {
+    const handleFileChange = (e) => {
+        const files = Array.from(e.target.files).map((file) => ({
+            name: file.name,
+            size: file.size,
+            type: file.type,
+        }));
+        updateData([...documents, ...files]);
+    };
+
+    return (
+        <div>
+            <h4>Step 3: Upload Documents</h4>
+            <input type="file" multiple onChange={handleFileChange} className="form-control mb-3" />
+            {documents.length > 0 && (
+                <ul>
+                    {documents.map((doc, i) => (
+                        <li key={i}>{doc.name}</li>
+                    ))}
+                </ul>
+            )}
+            <div className="d-flex gap-2">
+                <button className="btn btn-secondary" onClick={prevStep}>
+                    Back
+                </button>
+                <button className="btn btn-primary" onClick={nextStep}>
+                    Next
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/components/profiles/steps/StepPersonalInfo.jsx
+++ b/src/components/profiles/steps/StepPersonalInfo.jsx
@@ -1,0 +1,42 @@
+export default function StepPersonalInfo({ data, updateData, nextStep }) {
+    const handleChange = (e) => {
+        updateData(e.target.name, e.target.value);
+    };
+
+    return (
+        <div>
+            <h4>Step 1: Personal Info</h4>
+            <div className="mb-3">
+                <input
+                    type="text"
+                    name="firstName"
+                    className="form-control mb-2"
+                    placeholder="First Name*"
+                    value={data.firstName}
+                    onChange={handleChange}
+                    required
+                />
+                <input
+                    type="text"
+                    name="lastName"
+                    className="form-control mb-2"
+                    placeholder="Last Name*"
+                    value={data.lastName}
+                    onChange={handleChange}
+                    required
+                />
+                <input
+                    type="tel"
+                    name="phone"
+                    className="form-control mb-2"
+                    placeholder="Phone Number"
+                    value={data.phone}
+                    onChange={handleChange}
+                />
+            </div>
+            <button className="btn btn-primary" onClick={nextStep}>
+                Next
+            </button>
+        </div>
+    );
+}

--- a/src/components/profiles/steps/StepReviewSubmit.jsx
+++ b/src/components/profiles/steps/StepReviewSubmit.jsx
@@ -1,0 +1,16 @@
+export default function StepReviewSubmit({ data, prevStep, handleSubmit }) {
+    return (
+        <div>
+            <h4>Step 4: Review & Submit</h4>
+            <pre>{JSON.stringify(data, null, 2)}</pre>
+            <div className="d-flex gap-2">
+                <button className="btn btn-secondary" onClick={prevStep}>
+                    Back
+                </button>
+                <button className="btn btn-success" onClick={handleSubmit}>
+                    Submit Profile
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/components/profiles/steps/StepRoleSpecific.jsx
+++ b/src/components/profiles/steps/StepRoleSpecific.jsx
@@ -1,0 +1,63 @@
+export default function StepRoleSpecific({ role, data, updateData, nextStep, prevStep }) {
+    const handleChange = (e) => {
+        updateData({ ...data, [e.target.name]: e.target.value });
+    };
+
+    return (
+        <div>
+            <h4>Step 2: {role} Info</h4>
+            {role === 'FARMER' && (
+                <>
+                    <input
+                        type="text"
+                        name="farmName"
+                        className="form-control mb-2"
+                        placeholder="Farm Name*"
+                        value={data.farmName || ''}
+                        onChange={handleChange}
+                        required
+                    />
+                    <input
+                        type="text"
+                        name="farmLocation"
+                        className="form-control mb-2"
+                        placeholder="Farm Location*"
+                        value={data.farmLocation || ''}
+                        onChange={handleChange}
+                        required
+                    />
+                </>
+            )}
+            {role === 'INVESTOR' && (
+                <>
+                    <input
+                        type="text"
+                        name="companyName"
+                        className="form-control mb-2"
+                        placeholder="Company Name*"
+                        value={data.companyName || ''}
+                        onChange={handleChange}
+                        required
+                    />
+                    <input
+                        type="number"
+                        name="investmentAmount"
+                        className="form-control mb-2"
+                        placeholder="Investment Amount*"
+                        value={data.investmentAmount || ''}
+                        onChange={handleChange}
+                        required
+                    />
+                </>
+            )}
+            <div className="d-flex gap-2">
+                <button className="btn btn-secondary" onClick={prevStep}>
+                    Back
+                </button>
+                <button className="btn btn-primary" onClick={nextStep}>
+                    Next
+                </button>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
- Added ProfileCompletionForm with 4-step flow: Personal Info, Role-Specific Info, Document Upload, Review & Submit
- Integrated ProgressTracker component to visualize profile completion
- Connected form to PATCH /api/user/profile for step-wise updates
- Preserved incomplete states, allowing users to resume partially completed profiles
- Updated frontend logic to handle role-specific fields (Farmer / Investor)
- Ensured profileStage and profileCompletionPct are updated dynamically